### PR TITLE
Patch Minecraft doesn't launch and workingPath on OSX

### DIFF
--- a/app/assets/js/configmanager.js
+++ b/app/assets/js/configmanager.js
@@ -10,7 +10,7 @@ const path = require('path');
 const logger = require('./loggerutil')('%c[ConfigManager]', 'color: #a02d2a; font-weight: bold');
 
 const sysRoot = process.env.APPDATA || (process.platform == 'darwin' ? process.env.HOME + '/Library/Application Support' : process.env.HOME);
-const workingPath = path.join(sysRoot, '.paladium');
+const workingPath = path.join(sysRoot, 'paladium');
 
 exports.getWorkingDirectory = function() {
     return workingPath;
@@ -77,7 +77,7 @@ const DEFAULT_CONFIG = {
 let config = null;
 
 /**
- * Save the current configuration to a file. 
+ * Save the current configuration to a file.
  */
 exports.save = function() {
     fs.writeFileSync(configPath, JSON.stringify(config, null, 4), 'UTF-8');
@@ -92,7 +92,7 @@ exports.load = function() {
 
     if(!fs.existsSync(configPath)) {
         fs.ensureDirSync(path.join(configPath, '..'));
-        
+
         doLoad = false;
         config = DEFAULT_CONFIG;
         exports.save();
@@ -103,7 +103,7 @@ exports.load = function() {
         try {
             config = JSON.parse(fs.readFileSync(configPath, 'UTF-8'));
             doValidate = true;
-        } 
+        }
         catch (err) {
             logger.error(err);
             logger.log('Configuration file contains malformed JSON or is corrupt.');
@@ -139,7 +139,7 @@ function validateKeySet(srcObj, destObj) {
     for(let i=0; i < keys.length; i++) {
         if(typeof destObj[keys[i]] === 'undefined') {
             destObj[keys[i]] = srcObj[keys[i]];
-        } 
+        }
         else if(typeof srcObj[keys[i]] === 'object' && srcObj[keys[i]] != null && !(srcObj[keys[i]] instanceof Array) && validationBlacklist.indexOf(keys[i]) === -1) {
             destObj[keys[i]] = validateKeySet(srcObj[keys[i]], destObj[keys[i]]);
         }
@@ -230,7 +230,7 @@ exports.removeAuthAccount = function(uuid) {
             const keys = Object.keys(config.authenticationDatabase);
             if(keys.length > 0){
                 config.selectedAccount = keys[0];
-            } 
+            }
             else {
                 config.selectedAccount = null;
                 config.clientToken = null;


### PR DESCRIPTION
Liste des Patchs pour OSX:
 ∙ Ajout des args du Minecraft Launcher à la place de ceux originellement sur le JVMArguments
 ∙ Changement du .paladium en paladium pour aller plus facilement dans le dossier